### PR TITLE
Add Display Trait and fix Example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,35 @@ Licenses are retrieved by searching in the following order:
 * Text from `spdx` with identifier in `Cargo.toml`
 
 ## Usage
-```rust
-    // build.rs ==========
-    fn main() {
-        let config = license_retriever::Config {
-            // options...
-            ..Config::default()
-        };
-        license_retriever::LicenseRetriever::from_config(&config)?.save_in_out_dir("licenses")?;
-    }
+### *Cargo*
 
-    // main project ==========
-    fn main() {
-        let licenses = license_retriever::license_retriever_data!("licenses").unwrap(); // Vec<(Package, Vec<String>)>
-    }
+```
+cargo add license-retriever
+cargo add --build license-retriever
+```
+
+### `build.rs`
+
+```rust
+use license_retriever::{Config, LicenseRetriever};
+
+fn main() {
+    let config = Config {
+        // options...
+        ..Config::default()
+    };
+    LicenseRetriever::from_config(&config).unwrap().save_in_out_dir("LICENSE-3RD-PARTY").unwrap();
+}
+
+```
+
+### `main.rs`
+
+```rust
+use license_retriever;
+
+fn main() {
+    let licenses = license_retriever::license_retriever_data!("LICENSE-3RD-PARTY").unwrap();
+    println!("{}", licenses);
+}
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,23 +252,24 @@ impl IntoIterator for LicenseRetriever {
 
 impl fmt::Display for LicenseRetriever {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        const SEPERATOR_WIDTH: u32 = 80;
+        const SEPERATOR_WIDTH: usize = 80;
+        let separator: String = "=".repeat(SEPERATOR_WIDTH);
 
-        write!(f, "{:=<1}\n", SEPERATOR_WIDTH)?;
+        writeln!(f, "{}\n", separator)?;
 
         for (package, license) in self.iter() {
-            write!(f, "Package: {}", package.name)?;
-            write!(f, "Authors:")?;
+            writeln!(f, "Package: {}", package.name)?;
+            writeln!(f, "Authors:")?;
             for author in package.authors.iter() {
-                write!(f, " - {}", author)?;
+                writeln!(f, " - {}", author)?;
             }
-            write!(f, "\n{:=<1}\n", SEPERATOR_WIDTH)?;
+            writeln!(f, "\n{}\n", separator)?;
         
             for line in license.iter() {
-                write!(f, "{}", line)?;
+                writeln!(f, "{}", line)?;
             }
         
-            write!(f, "{:=<1}\n", SEPERATOR_WIDTH)?;
+            writeln!(f, "{}\n", separator)?;
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
+    fmt,
 };
 
 use cargo_metadata::{Metadata, MetadataCommand, Package};
@@ -246,6 +247,31 @@ impl IntoIterator for LicenseRetriever {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+impl fmt::Display for LicenseRetriever {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const SEPERATOR_WIDTH: u32 = 80;
+
+        write!(f, "{:=<1}\n", SEPERATOR_WIDTH)?;
+
+        for (package, license) in self.iter() {
+            write!(f, "Package: {}", package.name)?;
+            write!(f, "Authors:")?;
+            for author in package.authors.iter() {
+                write!(f, " - {}", author)?;
+            }
+            write!(f, "\n{:=<1}\n", SEPERATOR_WIDTH)?;
+        
+            for line in license.iter() {
+                write!(f, "{}", line)?;
+            }
+        
+            write!(f, "{:=<1}\n", SEPERATOR_WIDTH)?;
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
* Add `fmt::Display` trait.
* Fix example in Readme.
* Add instruction for adding crate with `cargo`.

closes: #19 #18 